### PR TITLE
Use options passed to the responsive image helper for the image_tag

### DIFF
--- a/lib/responsive_images/view_helpers.rb
+++ b/lib/responsive_images/view_helpers.rb
@@ -17,7 +17,7 @@ module ResponsiveImages
       # Get the image source
       image_src = src_path(image, sizes)      
       # Return the image tag with our responsive data attributes
-      return image_tag image_src, data_sizes
+      return image_tag image_src, data_sizes.merge(options)
     end
     
     


### PR DESCRIPTION
This allows using attributes for the image_tag like :class or :alt.

<%= responsive_image_tag image, :alt => name, :class => "img-responsive" %>
