### PR TITLE
Add default image support

### DIFF
--- a/vendor/assets/javascripts/responsive-images.js
+++ b/vendor/assets/javascripts/responsive-images.js
@@ -75,8 +75,7 @@
           // If the item is a div, let's set the background image
           if ( $(item).is('div') ) {
             $(item).css({
-              "background-image" : 'url("' + $(item).attr(data_attribute) + '")',
-              "background-size" : "auto",
+              "background-image" : 'url("' + $(item).attr(data_attribute) + '")'
             });
           }
           // If it's an image, let's just replace the source

--- a/vendor/assets/javascripts/responsive-images.js
+++ b/vendor/assets/javascripts/responsive-images.js
@@ -46,27 +46,27 @@
         responsive_images.settings.screen_width = $(window).width();
         responsive_images.settings.screen_height = $(window).height();        
       }      
-      // Set up our array of sizes and the closest match as null
-      var size = null;
-      var size_key = null;
-      var sizes = {
-        mobile_size: responsive_images.settings.mobile_size,
-        tablet_size: responsive_images.settings.tablet_size,
-        desktop_size: responsive_images.settings.desktop_size,
-      };
-      // Loop over our size array to figure out which size is the closest to our screen size
-      $.each(sizes, function(key, value) {
-        if (size == null || Math.abs(value - responsive_images.settings.screen_width) < Math.abs(size - responsive_images.settings.screen_width)) {
-          size = value;
-          size_key = key;
-        };
-      });
-      responsive_images.update_images(size_key, size);      
+      // Default image is considered the largest one
+      var size_key = 'default_size';
+      var sizes = [
+        ['desktop_size', responsive_images.settings.desktop_size],
+        ['tablet_size', responsive_images.settings.tablet_size],
+        ['mobile_size', responsive_images.settings.mobile_size],
+      ];
+      // Iterate over sizes and find one which matches current screen size
+      for(var i = 0; i < sizes.length; i++) {
+        // If screen width is larger than any breakpoint
+        if (responsive_images.settings.screen_width < sizes[i][1]) {
+          size_key = sizes[i][0];
+        }
+      }      
+      
+      responsive_images.update_images(size_key);      
     };
     
     
     // Update the actual images
-    responsive_images.update_images = function(key, size) {
+    responsive_images.update_images = function(key) {
       // Set up our data attribute
       var data_attribute = "data-" + key.replace("_", "-").replace('size', 'src');      
       responsive_images.each(function(index, item) {

--- a/vendor/assets/javascripts/responsive-images.js
+++ b/vendor/assets/javascripts/responsive-images.js
@@ -50,9 +50,9 @@
       var size = null;
       var size_key = null;
       var sizes = {
-        mobile_size: defaults.mobile_size,
-        tablet_size: defaults.tablet_size,
-        desktop_size: defaults.desktop_size,
+        mobile_size: responsive_images.settings.mobile_size,
+        tablet_size: responsive_images.settings.tablet_size,
+        desktop_size: responsive_images.settings.desktop_size,
       };
       // Loop over our size array to figure out which size is the closest to our screen size
       $.each(sizes, function(key, value) {


### PR DESCRIPTION
Fix for breakpoints settings, there was a bug.
Add support for `data-default-size` tag which when present will be used for screen width above largest breakpoint.